### PR TITLE
Добавлена гарда RefreshTokenGuard для роута auth/refresh #51

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,10 +1,10 @@
-import { Controller, Post, Body, Req } from '@nestjs/common';
+import { Controller, Post, Body, Req, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { TokensDto } from './dto/tokens.dto';
 import { RegisterDto } from './dto/register.dto';
 import { AuthenticatedRequest, LoginDto } from './interfaces/auth.interface';
-import { CreateUserDto } from '../users/dto/create-user.dto';
+import { RefreshTokenGuard } from './guards/refresh-token.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -21,12 +21,9 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @UseGuards(RefreshTokenGuard)
   async refresh(@Body() refreshTokenDto: RefreshTokenDto): Promise<TokensDto> {
     return this.authService.refreshTokens(refreshTokenDto);
-  }
-  @Post('register')
-  async register(@Body() createUserDto: CreateUserDto) {
-    return this.authService.register(createUserDto);
   }
 
   @Post('logout')

--- a/src/auth/guards/refresh-token.guard.spec.ts
+++ b/src/auth/guards/refresh-token.guard.spec.ts
@@ -1,8 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { RefreshTokenGuard } from './refresh-token.guard';
+import { RefreshTokenUser, AuthGuardError } from '../interfaces/auth.interface';
 
 describe('RefreshTokenGuard', () => {
   let guard: RefreshTokenGuard;
+
+  const mockExecutionContext = (body: any = {}): ExecutionContext => {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ body }),
+      }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+      getArgs: jest.fn(),
+      getArgByIndex: jest.fn(),
+      switchToRpc: jest.fn(),
+      switchToWs: jest.fn(),
+      getType: jest.fn(),
+    } as unknown as ExecutionContext;
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -16,7 +33,130 @@ describe('RefreshTokenGuard', () => {
     expect(guard).toBeDefined();
   });
 
-  it('should extend AuthGuard', () => {
-    expect(guard).toBeInstanceOf(RefreshTokenGuard);
+  describe('canActivate', () => {
+    it('should throw UnauthorizedException when refresh token is missing', () => {
+      const context = mockExecutionContext({});
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Refresh token is required',
+      );
+    });
+
+    it('should throw UnauthorizedException when refresh token is not a string', () => {
+      const context = mockExecutionContext({ refreshToken: 123 });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Refresh token must be a string',
+      );
+    });
+
+    it('should throw UnauthorizedException when refresh token is empty string', () => {
+      const context = mockExecutionContext({ refreshToken: '' });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Refresh token cannot be empty',
+      );
+    });
+
+    it('should throw UnauthorizedException when refresh token is only whitespace', () => {
+      const context = mockExecutionContext({ refreshToken: '   ' });
+
+      expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(context)).toThrow(
+        'Refresh token cannot be empty',
+      );
+    });
+  });
+
+  describe('handleRequest', () => {
+    it('should throw UnauthorizedException when there is an error', () => {
+      const error: AuthGuardError = {
+        name: 'AuthError',
+        message: 'Test error',
+        statusCode: 401,
+      };
+      const user: RefreshTokenUser | null = null;
+
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow('Invalid refresh token');
+    });
+
+    it('should throw UnauthorizedException when user is null', () => {
+      const error: AuthGuardError | null = null;
+      const user: RefreshTokenUser | null = null;
+
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow('Invalid refresh token');
+    });
+
+    it('should throw UnauthorizedException when user is undefined', () => {
+      const error: AuthGuardError | null = null;
+      const user: RefreshTokenUser | null = null;
+
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow('Invalid refresh token');
+    });
+
+    it('should throw UnauthorizedException when token type is not refresh', () => {
+      const error: AuthGuardError | null = null;
+      const user: RefreshTokenUser = {
+        userId: '123',
+        email: 'test@example.com',
+        role: 'USER',
+        refreshToken: 'test-token',
+        tokenType: 'access' as any,
+      };
+
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow(UnauthorizedException);
+      expect(() => {
+        guard.handleRequest(error, user);
+      }).toThrow('Invalid token type. Expected refresh token');
+    });
+
+    it('should return user when token type is refresh', () => {
+      const error: AuthGuardError | null = null;
+      const user: RefreshTokenUser = {
+        userId: '123',
+        email: 'test@example.com',
+        role: 'USER',
+        refreshToken: 'test-token',
+        tokenType: 'refresh',
+      };
+
+      const result = guard.handleRequest(error, user);
+
+      expect(result).toEqual(user);
+    });
+
+    it('should return user when token type is not specified', () => {
+      const error: AuthGuardError | null = null;
+      const user: RefreshTokenUser = {
+        userId: '123',
+        email: 'test@example.com',
+        role: 'USER',
+        refreshToken: 'test-token',
+      };
+
+      const result = guard.handleRequest(error, user);
+
+      expect(result).toEqual(user);
+    });
   });
 });

--- a/src/auth/guards/refresh-token.guard.ts
+++ b/src/auth/guards/refresh-token.guard.ts
@@ -1,5 +1,55 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Request } from 'express';
+import { RefreshTokenUser, AuthGuardError } from '../interfaces/auth.interface';
 
 @Injectable()
-export class RefreshTokenGuard extends AuthGuard('refresh-token') {}
+export class RefreshTokenGuard extends AuthGuard('refresh-token') {
+  canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    // Проверяем наличие refresh token в body
+    const refreshToken = request.body?.refreshToken;
+    if (!refreshToken && refreshToken !== '') {
+      throw new UnauthorizedException('Refresh token is required');
+    }
+
+    // Проверяем, что это строка
+    if (typeof refreshToken !== 'string') {
+      throw new UnauthorizedException('Refresh token must be a string');
+    }
+
+    // Проверяем, что токен не пустой
+    if (refreshToken.trim().length === 0) {
+      throw new UnauthorizedException('Refresh token cannot be empty');
+    }
+
+    return super.canActivate(context);
+  }
+
+  handleRequest<TUser = RefreshTokenUser>(
+    err: AuthGuardError | null,
+    user: RefreshTokenUser | null,
+    ...args: unknown[]
+  ): TUser {
+    // Игнорируем дополнительные аргументы
+    void args;
+    // Если есть ошибка или пользователь не найден
+    if (err || !user) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    // Проверяем, что это действительно refresh token
+    if (user.tokenType && user.tokenType !== 'refresh') {
+      throw new UnauthorizedException(
+        'Invalid token type. Expected refresh token',
+      );
+    }
+
+    return user as TUser;
+  }
+}

--- a/src/auth/interfaces/auth.interface.ts
+++ b/src/auth/interfaces/auth.interface.ts
@@ -40,3 +40,19 @@ export interface RefreshTokenPayload {
   iat?: number;
   exp?: number;
 }
+
+export interface RefreshTokenUser extends AuthenticatedUser {
+  refreshToken: string;
+  tokenType?: 'refresh';
+}
+
+export interface AuthGuardError extends Error {
+  message: string;
+  statusCode?: number;
+}
+
+export interface AuthGuardInfo {
+  message?: string;
+  scope?: string;
+  realm?: string;
+}

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './jwt.strategy';
 import { UsersService } from '../../users/users.service';
+import { Gender, UserRole } from '../../users/enums';
 
 describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
@@ -43,9 +44,9 @@ describe('JwtStrategy', () => {
       about: null,
       birthdate: null,
       city: null,
-      gender: 'male',
+      gender: Gender.MALE,
       avatar: null,
-      role: 'user',
+      role: UserRole.USER,
       createdAt: new Date(),
     };
     jest.spyOn(usersService, 'findOne').mockResolvedValue(mockUser);

--- a/src/auth/strategies/refresh-token.strategy.spec.ts
+++ b/src/auth/strategies/refresh-token.strategy.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { RefreshTokenStrategy } from './refresh-token.strategy';
 import { UsersService } from '../../users/users.service';
+import { Gender, UserRole } from '../../users/enums';
 import { Request } from 'express';
 
 describe('RefreshTokenStrategy', () => {
@@ -44,9 +45,9 @@ describe('RefreshTokenStrategy', () => {
       about: null,
       birthdate: null,
       city: null,
-      gender: 'male',
+      gender: Gender.MALE,
       avatar: null,
-      role: 'user',
+      role: UserRole.USER,
       createdAt: new Date(),
     };
     jest.spyOn(usersService, 'findOne').mockResolvedValue(mockUser);
@@ -70,7 +71,9 @@ describe('RefreshTokenStrategy', () => {
     expect(result).toEqual({
       userId: 'uuid-123',
       email: 'test@example.com',
+      role: UserRole.USER,
       refreshToken: 'test-refresh-token',
+      tokenType: 'refresh',
     });
   });
 

--- a/src/auth/strategies/refresh-token.strategy.spec.ts
+++ b/src/auth/strategies/refresh-token.strategy.spec.ts
@@ -4,10 +4,13 @@ import { RefreshTokenStrategy } from './refresh-token.strategy';
 import { UsersService } from '../../users/users.service';
 import { Gender, UserRole } from '../../users/enums';
 import { Request } from 'express';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RefreshToken } from '../entities/refresh-token.entity';
 
 describe('RefreshTokenStrategy', () => {
   let strategy: RefreshTokenStrategy;
   let usersService: UsersService;
+  let refreshTokenRepository: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -25,11 +28,19 @@ describe('RefreshTokenStrategy', () => {
             findOne: jest.fn(),
           },
         },
+        {
+          provide: getRepositoryToken(RefreshToken),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     strategy = module.get<RefreshTokenStrategy>(RefreshTokenStrategy);
     usersService = module.get<UsersService>(UsersService);
+    refreshTokenRepository = module.get(getRepositoryToken(RefreshToken));
   });
 
   it('should be defined', () => {
@@ -50,7 +61,20 @@ describe('RefreshTokenStrategy', () => {
       role: UserRole.USER,
       createdAt: new Date(),
     };
+
+    const mockTokenEntity = {
+      id: 1,
+      token: 'test-refresh-token',
+      isActive: true,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      user: mockUser,
+      userId: 'uuid-123',
+    };
+
     jest.spyOn(usersService, 'findOne').mockResolvedValue(mockUser);
+    jest
+      .spyOn(refreshTokenRepository, 'findOne')
+      .mockResolvedValue(mockTokenEntity);
 
     const payload = {
       sub: 'uuid-123',
@@ -62,7 +86,7 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      cookies: {
+      body: {
         refreshToken: 'test-refresh-token',
       },
     } as Request;
@@ -88,7 +112,7 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      cookies: {
+      body: {
         refreshToken: 'test-refresh-token',
       },
     } as Request;
@@ -109,11 +133,71 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      cookies: {},
+      body: {},
     } as Request;
 
     await expect(strategy.validate(req, payload)).rejects.toThrow(
       'Refresh token not found',
+    );
+  });
+
+  it('should throw UnauthorizedException when token is not found in DB', async () => {
+    const payload = {
+      sub: 'uuid-123',
+      email: 'test@example.com',
+      role: 'user',
+      tokenType: 'refresh' as const,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    jest.spyOn(refreshTokenRepository, 'findOne').mockResolvedValue(null);
+
+    const req = {
+      body: {
+        refreshToken: 'invalid-token',
+      },
+    } as Request;
+
+    await expect(strategy.validate(req, payload)).rejects.toThrow(
+      'Invalid refresh token',
+    );
+  });
+
+  it('should throw UnauthorizedException when token is expired', async () => {
+    const mockTokenEntity = {
+      id: 1,
+      token: 'expired-token',
+      isActive: true,
+      expiresAt: new Date(Date.now() - 1000), // Expired 1 second ago
+      user: null,
+      userId: 'uuid-123',
+    };
+
+    jest
+      .spyOn(refreshTokenRepository, 'findOne')
+      .mockResolvedValue(mockTokenEntity);
+    jest
+      .spyOn(refreshTokenRepository, 'save')
+      .mockResolvedValue(mockTokenEntity);
+
+    const payload = {
+      sub: 'uuid-123',
+      email: 'test@example.com',
+      role: 'user',
+      tokenType: 'refresh' as const,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const req = {
+      body: {
+        refreshToken: 'expired-token',
+      },
+    } as Request;
+
+    await expect(strategy.validate(req, payload)).rejects.toThrow(
+      'Refresh token expired',
     );
   });
 });

--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -4,6 +4,9 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 import { UsersService } from '../../users/users.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RefreshToken } from '../entities/refresh-token.entity';
 import {
   RefreshTokenPayload,
   RefreshTokenUser,
@@ -17,11 +20,13 @@ export class RefreshTokenStrategy extends PassportStrategy(
   constructor(
     private configService: ConfigService,
     private usersService: UsersService,
+    @InjectRepository(RefreshToken)
+    private refreshTokenRepository: Repository<RefreshToken>,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request): string | null => {
-          return (request?.cookies?.refreshToken as string) || null;
+          return (request?.body?.refreshToken as string) || null;
         },
       ]),
       ignoreExpiration: false,
@@ -36,7 +41,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
     req: Request,
     payload: RefreshTokenPayload,
   ): Promise<RefreshTokenUser> {
-    const refreshToken = req.cookies?.refreshToken;
+    const refreshToken = req.body?.refreshToken;
     if (!refreshToken) {
       throw new UnauthorizedException('Refresh token not found');
     }
@@ -46,12 +51,29 @@ export class RefreshTokenStrategy extends PassportStrategy(
       throw new UnauthorizedException('Неверный тип токена');
     }
 
+    // Валидируем токен против БД
+    const tokenEntity = await this.refreshTokenRepository.findOne({
+      where: { token: refreshToken, isActive: true },
+      relations: ['user'],
+    });
+
+    if (!tokenEntity) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    // Проверяем срок действия токена
+    if (new Date() > tokenEntity.expiresAt) {
+      // Деактивируем просроченный токен
+      tokenEntity.isActive = false;
+      await this.refreshTokenRepository.save(tokenEntity);
+      throw new UnauthorizedException('Refresh token expired');
+    }
+
     const user = await this.usersService.findOne(payload.sub);
     if (!user) {
       throw new UnauthorizedException('Пользователь не найден');
     }
 
-    // TODO: Add refresh token validation against stored token in DB
     return {
       userId: user.id,
       email: user.email,

--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -4,7 +4,10 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 import { UsersService } from '../../users/users.service';
-import { RefreshTokenPayload } from '../interfaces/auth.interface';
+import {
+  RefreshTokenPayload,
+  RefreshTokenUser,
+} from '../interfaces/auth.interface';
 
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(
@@ -29,7 +32,10 @@ export class RefreshTokenStrategy extends PassportStrategy(
     });
   }
 
-  async validate(req: Request, payload: RefreshTokenPayload) {
+  async validate(
+    req: Request,
+    payload: RefreshTokenPayload,
+  ): Promise<RefreshTokenUser> {
     const refreshToken = req.cookies?.refreshToken;
     if (!refreshToken) {
       throw new UnauthorizedException('Refresh token not found');
@@ -46,6 +52,12 @@ export class RefreshTokenStrategy extends PassportStrategy(
     }
 
     // TODO: Add refresh token validation against stored token in DB
-    return { userId: user.id, email: user.email, refreshToken };
+    return {
+      userId: user.id,
+      email: user.email,
+      role: user.role,
+      refreshToken,
+      tokenType: 'refresh' as const,
+    };
   }
 }

--- a/src/categories/entities/categories.entity.ts
+++ b/src/categories/entities/categories.entity.ts
@@ -1,16 +1,24 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from "typeorm";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
 
 @Entity('categories')
 export class Category {
-    @PrimaryGeneratedColumn()
-    id: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @Column({ type: 'varchar', length: 100 })
-    name: string
+  @Column({ type: 'varchar', length: 100 })
+  name: string;
 
-    @ManyToOne(() => Category, category => category.children, {nullable: true})
-    parent: Category
+  @ManyToOne(() => Category, (category) => category.children, {
+    nullable: true,
+  })
+  parent: Category;
 
-    @OneToMany(() => Category, category => category.parent)
-    children: Category[]
+  @OneToMany(() => Category, (category) => category.parent)
+  children: Category[];
 }


### PR DESCRIPTION
- Создана RefreshTokenGuard для защиты роута обновления токенов
- Добавлена RefreshTokenStrategy для валидации refresh токенов
- Реализована строгая типизация
- Добавлены интерфейсы RefreshTokenUser, AuthGuardError, AuthGuardInfo
- Обновлены тесты с правильной типизацией (Gender, UserRole enums)
- Гарда проверяет наличие, тип и валидность refresh токена
- Добавлена проверка типа токена (должен быть 'refresh')