### PR TITLE
Исправил проблему N+1 в методе update (исправить запросы) #131

### DIFF
--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -5,7 +5,7 @@ import {
   MinLength,
   IsEnum,
   IsOptional,
-  IsDateString
+  IsDateString,
 } from 'class-validator';
 import { Gender } from 'src/users/enums';
 

--- a/src/common/all-exception.filter.ts
+++ b/src/common/all-exception.filter.ts
@@ -21,20 +21,15 @@ export class AllExpectionFilter implements ExceptionFilter {
     if (exception instanceof HttpException) {
       status = exception.getStatus();
       message = exception.message;
-    }
-    else if (exception instanceof EntityNotFoundError) {
-      status = HttpStatus.NOT_FOUND
-      message = 'Entity not found'
-    }
-
-    else if (exception.code === '23505') {
-      status = HttpStatus.CONFLICT
-      message = 'Duplicate entry'
-    }
-
-    else if (exception instanceof PayloadTooLargeException) {
-      status = HttpStatus.PAYLOAD_TOO_LARGE
-      message = 'Payload too large'
+    } else if (exception instanceof EntityNotFoundError) {
+      status = HttpStatus.NOT_FOUND;
+      message = 'Entity not found';
+    } else if (exception.code === '23505') {
+      status = HttpStatus.CONFLICT;
+      message = 'Duplicate entry';
+    } else if (exception instanceof PayloadTooLargeException) {
+      status = HttpStatus.PAYLOAD_TOO_LARGE;
+      message = 'Payload too large';
     }
 
     return res.status(status).json({

--- a/src/requests/requests.service.ts
+++ b/src/requests/requests.service.ts
@@ -162,11 +162,11 @@ export class RequestsService {
     updateRequestDto: UpdateRequestDto,
     userId: string,
     userRole: string,
-  ): Promise<Request> {
-    // Находим заявку с полной информацией
+  ): Promise<{ message: string }> {
+    // Находим заявку БЕЗ relations (только для проверки прав)
     const request = await this.requestRepository.findOne({
       where: { id },
-      relations: ['sender', 'receiver', 'offeredSkill', 'requestedSkill'],
+      relations: ['sender', 'receiver'], // только для проверки прав
     });
 
     if (!request) {
@@ -182,28 +182,16 @@ export class RequestsService {
       throw new ForbiddenException('У вас нет прав для обновления этой заявки');
     }
 
-    // Обновляем поля
-    if (updateRequestDto.isRead !== undefined) {
-      request.isRead = updateRequestDto.isRead;
-    }
-
-    if (updateRequestDto.status !== undefined) {
-      request.status = updateRequestDto.status;
-    }
-
-    // Сохраняем изменения
-    const updatedRequest = await this.requestRepository.save(request);
-
-    // Возвращаем обновленную заявку с полной информацией
-    const result = await this.requestRepository.findOne({
-      where: { id: updatedRequest.id },
-      relations: ['sender', 'receiver', 'offeredSkill', 'requestedSkill'],
+    // Обновляем только нужные поля через update (более эффективно)
+    await this.requestRepository.update(id, {
+      ...(updateRequestDto.isRead !== undefined && {
+        isRead: updateRequestDto.isRead,
+      }),
+      ...(updateRequestDto.status !== undefined && {
+        status: updateRequestDto.status,
+      }),
     });
 
-    if (!result) {
-      throw new NotFoundException('Ошибка при обновлении заявки');
-    }
-
-    return result;
+    return { message: 'Заявка успешно обновлена' };
   }
 }


### PR DESCRIPTION
## Реализовано оптимальное решение:

### Устранена проблема N+1 запроса 

- **Сокращение запросов**: с 3 до 2 запросов к БД
- **Эффективное обновление**: использование `update()` вместо `save()`
- **Упрощен ответ API (простое сообщение)**
- **Возвращаемый тип**: `Promise<Request>` → `Promise<{ message: string }>`
- **Relations**: убраны `offeredSkill`, `requestedSkill` из первого запроса
- **Условное обновление**: использование spread operator для обновления только переданных полей