### PR TITLE
Фикс unit теста refresh-token.strategy.spec.ts #128

### DIFF
--- a/src/auth/strategies/refresh-token.strategy.spec.ts
+++ b/src/auth/strategies/refresh-token.strategy.spec.ts
@@ -6,6 +6,7 @@ import { Gender, UserRole } from '../../users/enums';
 import { Request } from 'express';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { RefreshToken } from '../entities/refresh-token.entity';
+import { User } from '../../users/entities/user.entity';
 
 describe('RefreshTokenStrategy', () => {
   let strategy: RefreshTokenStrategy;
@@ -59,8 +60,8 @@ describe('RefreshTokenStrategy', () => {
       gender: Gender.MALE,
       avatar: null,
       role: UserRole.USER,
-      createdAt: new Date(),
-    };
+      favoriteSkills: [],
+    } as unknown as User;
 
     const mockTokenEntity = {
       id: 1,
@@ -86,8 +87,8 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      body: {
-        refreshToken: 'test-refresh-token',
+      headers: {
+        authorization: 'Bearer test-refresh-token',
       },
     } as Request;
     const result = await strategy.validate(req, payload);
@@ -112,8 +113,8 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      body: {
-        refreshToken: 'test-refresh-token',
+      headers: {
+        authorization: 'Bearer test-refresh-token',
       },
     } as Request;
 
@@ -154,8 +155,8 @@ describe('RefreshTokenStrategy', () => {
     jest.spyOn(refreshTokenRepository, 'findOne').mockResolvedValue(null);
 
     const req = {
-      body: {
-        refreshToken: 'invalid-token',
+      headers: {
+        authorization: 'Bearer invalid-token',
       },
     } as Request;
 
@@ -191,8 +192,8 @@ describe('RefreshTokenStrategy', () => {
     };
 
     const req = {
-      body: {
-        refreshToken: 'expired-token',
+      headers: {
+        authorization: 'Bearer expired-token',
       },
     } as Request;
 


### PR DESCRIPTION
## Проблема
Unit тест `refresh-token.strategy.spec.ts` не проходил из-за двух основных проблем:

1. **Ошибка типизации**: Mock объект `mockUser` не содержал обязательное поле `favoriteSkills`, которое определено в сущности `User` как массив навыков (`Skill[]`).

2. **Неправильная передача токена**: Тесты передавали refresh token в теле запроса (`body.refreshToken`), в то время как стратегия ожидает токен в заголовке `Authorization` как Bearer token.

## Выполненные работы:

### 1. Исправление типизации mockUser
- Добавлено поле `favoriteSkills: []` в mock объект
- Использовано приведение типов `as unknown as User` для корректной работы с TypeScript
- Добавлен импорт сущности `User` для типизации

### 2. Исправление передачи токена в тестах
Исправлены все тесты для корректной передачи токена через заголовок Authorization