### PR TITLE
Авторизация в веб сокете через гарду, так как передавать id пользователя в теле небезопасно #149

### DIFF
--- a/src/notifications/guards/ws-jwt.guard.ts
+++ b/src/notifications/guards/ws-jwt.guard.ts
@@ -100,4 +100,3 @@ export class JwtWsGuard {
     return value;
   }
 }
- 

--- a/src/notifications/notifications.gateway.ts
+++ b/src/notifications/notifications.gateway.ts
@@ -2,14 +2,13 @@ import {
   WebSocketGateway,
   WebSocketServer,
   SubscribeMessage,
-  MessageBody,
   ConnectedSocket,
   OnGatewayConnection,
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { Notification } from './entities/notification.entity';
-import { JwtWsGuard } from './guards/ws-jwt.guard';
+import { JwtWsGuard, SocketWithUser } from './guards/ws-jwt.guard';
 
 export interface NotificationPayload {
   type: 'new' | 'accepted' | 'rejected';
@@ -58,13 +57,20 @@ export class NotificationsGateway
   }
 
   @SubscribeMessage('leave')
-  handleLeave(
-    @MessageBody() data: { userId: string },
-    @ConnectedSocket() client: Socket,
-  ) {
-    this.userConnections.delete(data.userId);
-    void client.leave(`user_${data.userId}`);
-    console.log(`User ${data.userId} left notifications room`);
+  handleLeave(@ConnectedSocket() client: Socket) {
+    // Получаем userId из авторизованных данных клиента
+    const userId = (client as SocketWithUser).data?.user?.userId;
+
+    if (!userId) {
+      console.log(
+        `Client ${client.id} attempted to leave without proper authentication`,
+      );
+      return;
+    }
+
+    this.userConnections.delete(userId);
+    void client.leave(`user_${userId}`);
+    console.log(`User ${userId} left notifications room`);
   }
 
   // Метод для отправки уведомления конкретному пользователю (в комнату user_<id>)

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -59,8 +59,8 @@ describe('UsersService', () => {
   const mockSkillsRepository = {
     create: jest.fn(),
     findOneOrFail: jest.fn(),
-    fondOneBy: jest.fn()
-  }
+    fondOneBy: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -76,8 +76,8 @@ describe('UsersService', () => {
         },
         {
           provide: getRepositoryToken(Skill),
-          useValue: mockSkillsRepository
-        }
+          useValue: mockSkillsRepository,
+        },
       ],
     }).compile();
 


### PR DESCRIPTION
## Проблемный код:

```typescript
@SubscribeMessage('leave')
handleLeave(
  @MessageBody() data: { userId: string },
  @ConnectedSocket() client: Socket,
) {
  this.userConnections.delete(data.userId);
  void client.leave(`user_${data.userId}`);
  console.log(`User ${data.userId} left notifications room`);
}
```

## Что сделано:

Исправлена уязвимость путем использования авторизованных данных пользователя из JWT токена вместо данных из тела сообщения.

### Исправленный код:

```typescript
@SubscribeMessage('leave')
handleLeave(@ConnectedSocket() client: Socket) {
  // Получаем userId из авторизованных данных клиента
  const userId = (client as SocketWithUser).data?.user?.userId;

  if (!userId) {
    console.log(`Client ${client.id} attempted to leave without proper authentication`);
    return;
  }

  this.userConnections.delete(userId);
  void client.leave(`user_${userId}`);
  console.log(`User ${userId} left notifications room`);
}
```

## Внесенные изменения

1. **Убран параметр `MessageBody`** - больше не принимаем `userId` из тела сообщения
2. **Добавлена проверка авторизации** - проверяем наличие `userId` в авторизованных данных
3. **Улучшена типизация** - используем интерфейс `SocketWithUser` вместо `any`
4. **Убран неиспользуемый импорт** - удален `MessageBody` из импортов
5. **Добавлена защита от неавторизованных запросов** - логируем попытки неавторизованного доступа
